### PR TITLE
Added Persona 5 Royal EU Encoding

### DIFF
--- a/AtlusScriptCompilerGUI/GUI.cs
+++ b/AtlusScriptCompilerGUI/GUI.cs
@@ -34,6 +34,7 @@ namespace AtlusScriptCompilerGUI
             "Persona 4 Golden",
             "Persona 5",
             "Persona 5 Royal",
+            "Persona 5 Royal - EU",
             "Persona Q2",
         };
 
@@ -210,7 +211,16 @@ namespace AtlusScriptCompilerGUI
                     if (extension == ".FLOW")
                         outFormatArg = "-OutFormat V3BE";
                     break;
-                case 9: //PQ2
+                case 9: //P5REU
+                    encodingArg = "-Encoding P5R_EFIGS";
+                    if (extension != ".BMD")
+                        libraryArg = "-Library P5R";
+                    if (extension == ".MSG")
+                        outFormatArg = "-OutFormat V1";
+                    if (extension == ".FLOW")
+                        outFormatArg = "-OutFormat V3BE";
+                    break;
+                case 10: //PQ2
                     encodingArg = "-Encoding SJ";
                     if (extension != ".BMD")
                         libraryArg = "-Library PQ2";

--- a/AtlusScriptCompilerGUI/GUI.cs
+++ b/AtlusScriptCompilerGUI/GUI.cs
@@ -216,7 +216,7 @@ namespace AtlusScriptCompilerGUI
                     if (extension != ".BMD")
                         libraryArg = "-Library P5R";
                     if (extension == ".MSG")
-                        outFormatArg = "-OutFormat V1";
+                        outFormatArg = "-OutFormat V1"; //V1 = Persona 5 PS4 Output
                     if (extension == ".FLOW")
                         outFormatArg = "-OutFormat V3BE";
                     break;


### PR DESCRIPTION
I added a new Selectable Game Option as "Persona 5 Royal - EU" 
This uses the Encoding "P5R_EFIGS" which are the Charsets for the European Languages (English, French, Italian, German, Spanish)